### PR TITLE
Fix typos in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //!         // Read a request.
 //!         let request = read_request();
-//!         // Pas the request_context along with the request to the requst
+//!         // Pass the request_context along with the request to the request
 //!         // handler.
 //!         let response = handle_request(request_context, request).unwrap();
 //!         println!("got response: {:?}", response);


### PR DESCRIPTION
There were some typos in a comment in the first example, which are pretty immediately visible! Just wanted to fix those so it looks nicer on the first read.